### PR TITLE
Allow nonconformant spaces in headers

### DIFF
--- a/textproto/header.go
+++ b/textproto/header.go
@@ -430,7 +430,7 @@ func isSpace(c byte) bool {
 
 func validHeaderKeyByte(b byte) bool {
 	c := int(b)
-	return c >= 33 && c <= 126 && c != ':'
+	return c >= 32 && c <= 126 && c != ':'
 }
 
 // trim returns s with leading and trailing spaces and tabs removed.


### PR DESCRIPTION
This loosens the restrictions on valid header keys from a strict RFC interpretation to one that also permits `' '` / `0x20` / `32` bytes, which can be observed by some in-the-wild, non-conformant systems. These headers appear to be ignored by clients anyway, but we need to parse them regardless.

<!-- https://www.notion.so/sublimesecurity/1cb04655fc9d8171aa2ff7efe6313045 -->