### PR TITLE
Handle consecutive multipart boundaries

### DIFF
--- a/textproto/multipart.go
+++ b/textproto/multipart.go
@@ -84,6 +84,13 @@ func newPart(mr *MultipartReader) (*Part, error) {
 }
 
 func (bp *Part) populateHeaders() error {
+	// If there are consecutive boundaries, just return an empty header.
+	peek, _ := bp.mr.bufReader.Peek(len(bp.mr.dashBoundary))
+	if bytes.HasPrefix(peek, bp.mr.dashBoundary) {
+		bp.Header = Header{}
+		return nil
+	}
+
 	header, err := ReadHeader(bp.mr.bufReader)
 	if err == nil {
 		bp.Header = header

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -760,6 +760,30 @@ val
 		},
 	},
 
+	// Two consecutive boundaries - represents an empty part between them
+	{
+		name: "two consecutive boundaries",
+		sep:  "gc0p4Jq0M2Yt08jU534c0p",
+		in:   "--gc0p4Jq0M2Yt08jU534c0p\r\nContent-Type: text/plain\r\n\r\nfirst part\r\n--gc0p4Jq0M2Yt08jU534c0p\r\n--gc0p4Jq0M2Yt08jU534c0p\r\nContent-Type: text/html\r\n\r\nlast part\r\n--gc0p4Jq0M2Yt08jU534c0p--",
+		want: []headerBody{
+			{textproto.MIMEHeader{"Content-Type": {"text/plain"}}, "first part"},
+			{textproto.MIMEHeader{}, ""}, // Empty part from consecutive boundaries
+			{textproto.MIMEHeader{"Content-Type": {"text/html"}}, "last part"},
+		},
+	},
+
+	// Three consecutive boundaries - represents two empty parts
+	{
+		name: "three consecutive boundaries",
+		sep:  "gc0p4Jq0M2Yt08jU534c0p",
+		in:   "--gc0p4Jq0M2Yt08jU534c0p\r\n--gc0p4Jq0M2Yt08jU534c0p\r\n--gc0p4Jq0M2Yt08jU534c0p\r\nContent-Type: text/plain\r\n\r\nfinal part body\r\n--gc0p4Jq0M2Yt08jU534c0p--",
+		want: []headerBody{
+			{textproto.MIMEHeader{}, ""}, // First empty part
+			{textproto.MIMEHeader{}, ""}, // Second empty part
+			{textproto.MIMEHeader{"Content-Type": {"text/plain"}}, "final part body"},
+		},
+	},
+
 	roundTripParseTest(),
 }
 

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -877,3 +877,14 @@ func TestNoBoundary(t *testing.T) {
 		t.Errorf("NextPart error = %v; want %v", got, want)
 	}
 }
+
+func TestInvalidLineAfterBoundary(t *testing.T) {
+	testBody := "--MyBoundary\r\nThis is not a valid header line\r\n"
+	bodyReader := strings.NewReader(testBody)
+	reader := NewMultipartReader(bodyReader, "MyBoundary")
+	_, err := reader.NextPart()
+
+	if err == nil {
+		t.Error("Expected an error when parsing invalid line after boundary, got nil")
+	}
+}


### PR DESCRIPTION
In a recently reported bug, a message with two consecutive boundaries was not processed because the `MultipartReader` returned an error: "malformed MIME header line". When there are consecutive multipart boundaries, we should return empty parts between those boundaries. 

The `peek` and comparison happens once per part of a multipart body. This should have negligible performance impact.