### PR TITLE
hack to fix line length issues for quoted-printable

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -31,7 +31,7 @@ func encodingReader(enc string, r io.Reader) (io.Reader, error) {
 	var dec io.Reader
 	switch strings.ToLower(enc) {
 	case "quoted-printable":
-		dec = quotedprintable.NewReader(bufio.NewReaderSize(r, 1024*8*8))
+		dec = quotedprintable.NewReader(bufio.NewReaderSize(r, 1024*8))
 	case "base64":
 		wrapped := &whitespaceReplacingReader{wrapped: r}
 		dec = base64.NewDecoder(base64.StdEncoding, wrapped)

--- a/encoding.go
+++ b/encoding.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/base64"
 	"errors"
@@ -30,7 +31,7 @@ func encodingReader(enc string, r io.Reader) (io.Reader, error) {
 	var dec io.Reader
 	switch strings.ToLower(enc) {
 	case "quoted-printable":
-		dec = quotedprintable.NewReader(r)
+		dec = quotedprintable.NewReader(bufio.NewReaderSize(r, 1024*8*8))
 	case "base64":
 		wrapped := &whitespaceReplacingReader{wrapped: r}
 		dec = base64.NewDecoder(base64.StdEncoding, wrapped)


### PR DESCRIPTION
###Description

Hack fix for https://github.com/emersion/go-message/issues/137. This doesn't solve the issue fully (a line longer than this will also fail to read in), but I'm operating under the assumption that spammers make long lines with the thinking that most buffers will be around 4KB, so pretty much anything significantly over that should be okay.

###How did you validate this change?
In local dev I fully read in the HTML in https://sublimesecurity.slack.com/archives/C021793F005/p1773258736726869

###How would you rollback this change?
Okay to revert.