### PR TITLE
skip malformed header lines instead of error

### DIFF
--- a/textproto/header.go
+++ b/textproto/header.go
@@ -547,7 +547,8 @@ func ReadHeader(r *bufio.Reader) (Header, error) {
 		// appear in the wild, violating specs, so we remove them if present.
 		i := bytes.IndexByte(kv, ':')
 		if i < 0 {
-			return newHeader(fs), fmt.Errorf("message: malformed MIME header line: %v", string(kv))
+			// Skip malformed header lines (no colon).
+			continue
 		}
 
 		keyBytes := trim(kv[:i])

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -879,12 +879,15 @@ func TestNoBoundary(t *testing.T) {
 }
 
 func TestInvalidLineAfterBoundary(t *testing.T) {
-	testBody := "--MyBoundary\r\nThis is not a valid header line\r\n"
+	testBody := "--MyBoundary\r\nThis is not a valid header line\r\nContent-Type: text/plain\r\n\r\nhello\r\n--MyBoundary--\r\n"
 	bodyReader := strings.NewReader(testBody)
 	reader := NewMultipartReader(bodyReader, "MyBoundary")
-	_, err := reader.NextPart()
+	part, err := reader.NextPart()
 
-	if err == nil {
-		t.Error("Expected an error when parsing invalid line after boundary, got nil")
+	if err != nil {
+		t.Fatalf("Expected successful parse skipping malformed line, got error: %v", err)
+	}
+	if part.Header.Get("Content-Type") != "text/plain" {
+		t.Errorf("Expected Content-Type text/plain, got %q", part.Header.Get("Content-Type"))
 	}
 }


### PR DESCRIPTION
https://app.notion.com/p/sublimesecurity/Fix-MIME-parsing-issues-identified-during-hackathon-3aa04655fc9d8105a072c216f06ee880

From local testing, Apple Mail and Outlook are very tolerant of non-header lines after content boundaries. So instead of erroring and killing the whole part, just continue and skip the line. Gmail is not tolerant of it, but we'd rather be more permissive in our parsing.

Identified from 2026 hackathon, fix implemented by Claude.