### PR TITLE
Tolerate malformed part headers in multipart parsing

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -235,7 +235,7 @@ func (e *Entity) Walk(walkFunc WalkFunc) error {
 				multipartReaders = multipartReaders[:len(multipartReaders)-1]
 				path = path[:len(path)-1]
 				continue
-			} else if IsUnknownEncoding(err) || IsUnknownCharset(err) {
+			} else if IsUnknownEncoding(err) || IsUnknownCharset(err) || textproto.IsMalformedPartHeader(err) {
 				// Forward the error to walkFunc
 			} else if err != nil {
 				return err

--- a/entity.go
+++ b/entity.go
@@ -235,7 +235,7 @@ func (e *Entity) Walk(walkFunc WalkFunc) error {
 				multipartReaders = multipartReaders[:len(multipartReaders)-1]
 				path = path[:len(path)-1]
 				continue
-			} else if IsUnknownEncoding(err) || IsUnknownCharset(err) || textproto.IsMalformedPartHeader(err) {
+			} else if IsUnknownEncoding(err) || IsUnknownCharset(err) || (err != nil && part != nil) {
 				// Forward the error to walkFunc
 			} else if err != nil {
 				return err

--- a/entity.go
+++ b/entity.go
@@ -235,11 +235,8 @@ func (e *Entity) Walk(walkFunc WalkFunc) error {
 				multipartReaders = multipartReaders[:len(multipartReaders)-1]
 				path = path[:len(path)-1]
 				continue
-			} else if IsUnknownEncoding(err) || IsUnknownCharset(err) {
+			} else if IsUnknownEncoding(err) || IsUnknownCharset(err) || IsMalformedPartHeader(err) {
 				// Forward the error to walkFunc
-			} else if part != nil {
-				// A non-nil part means headers were recovered despite the error;
-				// the part is safe to use, so forward the error rather than failing.
 			} else if err != nil {
 				return err
 			}

--- a/entity.go
+++ b/entity.go
@@ -237,7 +237,7 @@ func (e *Entity) Walk(walkFunc WalkFunc) error {
 				continue
 			} else if IsUnknownEncoding(err) || IsUnknownCharset(err) {
 				// Forward the error to walkFunc
-			} else if err != nil && part != nil {
+			} else if part != nil {
 				// A non-nil part means headers were recovered despite the error;
 				// the part is safe to use, so forward the error rather than failing.
 			} else if err != nil {

--- a/entity.go
+++ b/entity.go
@@ -235,8 +235,11 @@ func (e *Entity) Walk(walkFunc WalkFunc) error {
 				multipartReaders = multipartReaders[:len(multipartReaders)-1]
 				path = path[:len(path)-1]
 				continue
-			} else if IsUnknownEncoding(err) || IsUnknownCharset(err) || (err != nil && part != nil) {
+			} else if IsUnknownEncoding(err) || IsUnknownCharset(err) {
 				// Forward the error to walkFunc
+			} else if err != nil && part != nil {
+				// A non-nil part means headers were recovered despite the error;
+				// the part is safe to use, so forward the error rather than failing.
 			} else if err != nil {
 				return err
 			}

--- a/entity_test.go
+++ b/entity_test.go
@@ -635,10 +635,6 @@ func TestWalk_multipart(t *testing.T) {
 	}
 }
 
-// TestWalk_malformedPartHeader verifies that a part with a single bad header
-// line (no colon) doesn't abort Walk: the recovered part is still visited
-// with a usable header and body, its error verifies IsMalformedPartHeader,
-// and later siblings are still reached.
 func TestWalk_malformedPartHeader(t *testing.T) {
 	raw := "Mime-Version: 1.0\r\n" +
 		"Content-Type: multipart/mixed; boundary=sep\r\n\r\n" +

--- a/entity_test.go
+++ b/entity_test.go
@@ -634,3 +634,53 @@ func TestWalk_multipart(t *testing.T) {
 		t.Errorf("Entity.Walk() =\n%#v\nbut want:\n%#v", got, want)
 	}
 }
+
+// TestWalk_malformedPartHeader verifies that a part with a single bad header
+// line (no colon) doesn't abort Walk: the recovered part is still visited
+// with a usable header and body, its error verifies IsMalformedPartHeader,
+// and later siblings are still reached.
+func TestWalk_malformedPartHeader(t *testing.T) {
+	raw := "Mime-Version: 1.0\r\n" +
+		"Content-Type: multipart/mixed; boundary=sep\r\n\r\n" +
+		"--sep\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"Text part\r\n" +
+		"--sep\r\n" +
+		"X-Notice this line is not a valid header field\r\n" +
+		"Content-Type: text/html\r\n" +
+		"\r\n" +
+		"<p>HTML part</p>\r\n" +
+		"--sep\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"Trailing part\r\n" +
+		"--sep--\r\n"
+
+	e, err := Read(strings.NewReader(raw))
+	if err != nil {
+		t.Fatalf("Read() = %v", err)
+	}
+
+	got, err := walkCollect(e)
+	if err != nil {
+		t.Fatalf("Entity.Walk() = %v", err)
+	}
+
+	// got[0] is the multipart/mixed root; got[1..3] are its three children.
+	if len(got) != 4 {
+		t.Fatalf("Entity.Walk() visited %d parts, want 4: %#v", len(got), got)
+	}
+
+	if got[2].mediaType != "text/html" || got[2].body != "<p>HTML part</p>" {
+		t.Errorf("recovered part = %#v, want text/html body <p>HTML part</p>", got[2])
+	}
+	if !IsMalformedPartHeader(got[2].err) {
+		t.Errorf("recovered part err = %v, want IsMalformedPartHeader", got[2].err)
+	}
+
+	// The part after the recovered one must still be reached.
+	if got[3].mediaType != "text/plain" || got[3].body != "Trailing part" {
+		t.Errorf("trailing sibling = %#v, want text/plain body Trailing part", got[3])
+	}
+}

--- a/multipart.go
+++ b/multipart.go
@@ -35,6 +35,15 @@ func (r *multipartReader) NextPart() (*Entity, error) {
 	return e, err
 }
 
+// IsMalformedPartHeader returns a boolean indicating whether the error is
+// known to report that a multipart part's header block contained an
+// unparseable line. If NextPart also returned a non-nil Entity alongside
+// this error, the headers were recovered from the surrounding valid lines
+// and are safe to use.
+func IsMalformedPartHeader(err error) bool {
+	return textproto.IsMalformedPartHeader(err)
+}
+
 // Close implements io.Closer.
 func (r *multipartReader) Close() error {
 	return nil

--- a/multipart.go
+++ b/multipart.go
@@ -25,10 +25,14 @@ type multipartReader struct {
 // NextPart implements MultipartReader.
 func (r *multipartReader) NextPart() (*Entity, error) {
 	p, err := r.r.NextPart()
-	if err != nil {
+	if err != nil && p == nil {
 		return nil, err
 	}
-	return New(Header{p.Header}, p)
+	e, entityErr := New(Header{p.Header}, p)
+	if entityErr != nil {
+		return e, entityErr
+	}
+	return e, err
 }
 
 // Close implements io.Closer.

--- a/multipart.go
+++ b/multipart.go
@@ -35,11 +35,9 @@ func (r *multipartReader) NextPart() (*Entity, error) {
 	return e, err
 }
 
-// IsMalformedPartHeader returns a boolean indicating whether the error is
-// known to report that a multipart part's header block contained an
-// unparseable line. If NextPart also returned a non-nil Entity alongside
-// this error, the headers were recovered from the surrounding valid lines
-// and are safe to use.
+// IsMalformedPartHeader reports whether err is due to an unparseable line in
+// a multipart part's header. A non-nil Entity from NextPart alongside it
+// means the headers were recovered and are safe to use.
 func IsMalformedPartHeader(err error) bool {
 	return textproto.IsMalformedPartHeader(err)
 }

--- a/textproto/multipart.go
+++ b/textproto/multipart.go
@@ -74,6 +74,28 @@ func (r *stickyErrorReader) Read(p []byte) (n int, _ error) {
 	return n, r.err
 }
 
+// MalformedPartHeaderError is returned by NextPart when a part's header block
+// contains a line that cannot be parsed. If the reader was able to recover
+// valid headers from the remaining lines, the Part is non-nil and its Header
+// contains whatever was successfully parsed after the bad line.
+type MalformedPartHeaderError struct {
+	Err error
+}
+
+func (e *MalformedPartHeaderError) Error() string {
+	return "multipart: malformed part header: " + e.Err.Error()
+}
+
+func (e *MalformedPartHeaderError) Unwrap() error {
+	return e.Err
+}
+
+// IsMalformedPartHeader reports whether err is a MalformedPartHeaderError.
+func IsMalformedPartHeader(err error) bool {
+	var e *MalformedPartHeaderError
+	return errors.As(err, &e)
+}
+
 func newPart(mr *MultipartReader) (*Part, error) {
 	bp := &Part{mr: mr}
 	if err := bp.populateHeaders(); err != nil {
@@ -85,7 +107,7 @@ func newPart(mr *MultipartReader) (*Part, error) {
 		if recoveryErr := bp.populateHeaders(); recoveryErr == nil {
 			// Recovered: part != nil signals the headers are usable.
 			bp.r = partReader{bp}
-			return bp, err
+			return bp, &MalformedPartHeaderError{Err: err}
 		}
 		// Recovery failed. Discard through the part boundary so the reader is
 		// left in a valid state for the next NextPart call.
@@ -93,7 +115,7 @@ func newPart(mr *MultipartReader) (*Part, error) {
 		discard.r = partReader{discard}
 		io.Copy(io.Discard, discard)
 		// part == nil signals the part was unrecoverable.
-		return nil, err
+		return nil, &MalformedPartHeaderError{Err: err}
 	}
 	bp.r = partReader{bp}
 	return bp, nil

--- a/textproto/multipart.go
+++ b/textproto/multipart.go
@@ -74,10 +74,46 @@ func (r *stickyErrorReader) Read(p []byte) (n int, _ error) {
 	return n, r.err
 }
 
+// MalformedPartHeaderError is returned by NextPart when a part's header block
+// contains a line that cannot be parsed. If the reader was able to recover
+// valid headers from the remaining lines, the Part is non-nil and its Header
+// contains whatever was successfully parsed after the bad line.
+type MalformedPartHeaderError struct {
+	Err error
+}
+
+func (e *MalformedPartHeaderError) Error() string {
+	return "multipart: malformed part header: " + e.Err.Error()
+}
+
+func (e *MalformedPartHeaderError) Unwrap() error {
+	return e.Err
+}
+
+// IsMalformedPartHeader reports whether err is a MalformedPartHeaderError.
+func IsMalformedPartHeader(err error) bool {
+	var e *MalformedPartHeaderError
+	return errors.As(err, &e)
+}
+
 func newPart(mr *MultipartReader) (*Part, error) {
 	bp := &Part{mr: mr}
 	if err := bp.populateHeaders(); err != nil {
-		return nil, err
+		// The header block contained at least one unparseable line. ReadHeader
+		// consumed that line and stopped, so the reader is now positioned at
+		// the next line. Try once more: if the remaining lines form a valid
+		// header block (e.g. a single bad line preceded otherwise-valid headers)
+		// we can still deliver the part to the caller.
+		if recoveryErr := bp.populateHeaders(); recoveryErr == nil {
+			bp.r = partReader{bp}
+			return bp, &MalformedPartHeaderError{Err: err}
+		}
+		// Recovery failed. Discard through the part boundary so the reader is
+		// left in a valid state for the next NextPart call.
+		discard := &Part{mr: mr}
+		discard.r = partReader{discard}
+		io.Copy(io.Discard, discard)
+		return nil, &MalformedPartHeaderError{Err: err}
 	}
 	bp.r = partReader{bp}
 	return bp, nil
@@ -286,11 +322,11 @@ func (r *MultipartReader) NextPart() (*Part, error) {
 		if r.isBoundaryDelimiterLine(line) {
 			r.partsRead++
 			bp, err := newPart(r)
-			if err != nil {
+			if err != nil && bp == nil {
 				return nil, err
 			}
 			r.currentPart = bp
-			return bp, nil
+			return bp, err
 		}
 
 		if r.isFinalBoundary(line) {

--- a/textproto/multipart.go
+++ b/textproto/multipart.go
@@ -74,10 +74,9 @@ func (r *stickyErrorReader) Read(p []byte) (n int, _ error) {
 	return n, r.err
 }
 
-// MalformedPartHeaderError is returned by NextPart when a part's header block
-// contains a line that cannot be parsed. If the reader was able to recover
-// valid headers from the remaining lines, the Part is non-nil and its Header
-// contains whatever was successfully parsed after the bad line.
+// MalformedPartHeaderError is returned by NextPart when a part's header
+// contains an unparseable line. A non-nil Part means the rest of the
+// header was recovered and is safe to use.
 type MalformedPartHeaderError struct {
 	Err error
 }

--- a/textproto/multipart.go
+++ b/textproto/multipart.go
@@ -74,28 +74,6 @@ func (r *stickyErrorReader) Read(p []byte) (n int, _ error) {
 	return n, r.err
 }
 
-// MalformedPartHeaderError is returned by NextPart when a part's header block
-// contains a line that cannot be parsed. If the reader was able to recover
-// valid headers from the remaining lines, the Part is non-nil and its Header
-// contains whatever was successfully parsed after the bad line.
-type MalformedPartHeaderError struct {
-	Err error
-}
-
-func (e *MalformedPartHeaderError) Error() string {
-	return "multipart: malformed part header: " + e.Err.Error()
-}
-
-func (e *MalformedPartHeaderError) Unwrap() error {
-	return e.Err
-}
-
-// IsMalformedPartHeader reports whether err is a MalformedPartHeaderError.
-func IsMalformedPartHeader(err error) bool {
-	var e *MalformedPartHeaderError
-	return errors.As(err, &e)
-}
-
 func newPart(mr *MultipartReader) (*Part, error) {
 	bp := &Part{mr: mr}
 	if err := bp.populateHeaders(); err != nil {
@@ -105,15 +83,17 @@ func newPart(mr *MultipartReader) (*Part, error) {
 		// header block (e.g. a single bad line preceded otherwise-valid headers)
 		// we can still deliver the part to the caller.
 		if recoveryErr := bp.populateHeaders(); recoveryErr == nil {
+			// Recovered: part != nil signals the headers are usable.
 			bp.r = partReader{bp}
-			return bp, &MalformedPartHeaderError{Err: err}
+			return bp, err
 		}
 		// Recovery failed. Discard through the part boundary so the reader is
 		// left in a valid state for the next NextPart call.
 		discard := &Part{mr: mr}
 		discard.r = partReader{discard}
 		io.Copy(io.Discard, discard)
-		return nil, &MalformedPartHeaderError{Err: err}
+		// part == nil signals the part was unrecoverable.
+		return nil, err
 	}
 	bp.r = partReader{bp}
 	return bp, nil

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -917,15 +917,14 @@ func TestInvalidLineAfterBoundary(t *testing.T) {
 	reader := NewMultipartReader(bodyReader, "MyBoundary")
 	_, err := reader.NextPart()
 
-	if !IsMalformedPartHeader(err) {
-		t.Errorf("Expected IsMalformedPartHeader error when parsing invalid line after boundary, got %v", err)
+	if err == nil {
+		t.Errorf("Expected non-nil error when parsing invalid line after boundary")
 	}
 }
 
 // TestMalformedPartHeaderRecovery tests that a part with a single bad header
-// line (no colon) followed by valid headers is recovered: the part is returned
-// with the recovered headers and a MalformedPartHeaderError, and subsequent
-// parts are parsed normally.
+// line (no colon) followed by valid headers is recovered: the part is non-nil
+// with usable headers (err non-nil), and subsequent parts are parsed normally.
 func TestMalformedPartHeaderRecovery(t *testing.T) {
 	// Mirrors a real-world multipart/alternative where the second part starts
 	// with a line that has no colon before the real headers.
@@ -954,13 +953,13 @@ func TestMalformedPartHeaderRecovery(t *testing.T) {
 		t.Errorf("part 1 body: got %q, want %q", got, want)
 	}
 
-	// Part 2: bad header line, followed by valid headers.
+	// Part 2: bad header line, followed by valid headers — part is non-nil (recovered) but err is non-nil.
 	p, err = r.NextPart()
-	if !IsMalformedPartHeader(err) {
-		t.Fatalf("part 2 NextPart: expected IsMalformedPartHeader, got %v", err)
-	}
 	if p == nil {
-		t.Fatal("part 2 NextPart: expected non-nil part with recovered headers")
+		t.Fatalf("part 2 NextPart: expected non-nil part with recovered headers, got err %v", err)
+	}
+	if err == nil {
+		t.Fatal("part 2 NextPart: expected non-nil error for malformed header")
 	}
 	if got, want := p.Header.Get("Content-Type"), "text/html; charset=utf-8"; got != want {
 		t.Errorf("part 2 Content-Type: got %q, want %q", got, want)
@@ -996,8 +995,8 @@ func TestMalformedPartHeaderSkip(t *testing.T) {
 
 	// Part 1: unrecoverable – two bad lines – returns nil part + error.
 	p, err := r.NextPart()
-	if !IsMalformedPartHeader(err) {
-		t.Fatalf("part 1 NextPart: expected IsMalformedPartHeader, got %v", err)
+	if err == nil {
+		t.Fatalf("part 1 NextPart: expected non-nil error for unrecoverable header")
 	}
 	if p != nil {
 		t.Fatal("part 1 NextPart: expected nil part when recovery fails")

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -917,8 +917,8 @@ func TestInvalidLineAfterBoundary(t *testing.T) {
 	reader := NewMultipartReader(bodyReader, "MyBoundary")
 	_, err := reader.NextPart()
 
-	if err == nil {
-		t.Errorf("Expected non-nil error when parsing invalid line after boundary")
+	if !IsMalformedPartHeader(err) {
+		t.Errorf("Expected IsMalformedPartHeader error when parsing invalid line after boundary, got %v", err)
 	}
 }
 
@@ -958,8 +958,8 @@ func TestMalformedPartHeaderRecovery(t *testing.T) {
 	if p == nil {
 		t.Fatalf("part 2 NextPart: expected non-nil part with recovered headers, got err %v", err)
 	}
-	if err == nil {
-		t.Fatal("part 2 NextPart: expected non-nil error for malformed header")
+	if !IsMalformedPartHeader(err) {
+		t.Fatalf("part 2 NextPart: expected IsMalformedPartHeader error, got %v", err)
 	}
 	if got, want := p.Header.Get("Content-Type"), "text/html; charset=utf-8"; got != want {
 		t.Errorf("part 2 Content-Type: got %q, want %q", got, want)
@@ -995,8 +995,8 @@ func TestMalformedPartHeaderSkip(t *testing.T) {
 
 	// Part 1: unrecoverable – two bad lines – returns nil part + error.
 	p, err := r.NextPart()
-	if err == nil {
-		t.Fatalf("part 1 NextPart: expected non-nil error for unrecoverable header")
+	if !IsMalformedPartHeader(err) {
+		t.Fatalf("part 1 NextPart: expected IsMalformedPartHeader error, got %v", err)
 	}
 	if p != nil {
 		t.Fatal("part 1 NextPart: expected nil part when recovery fails")

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -917,8 +917,108 @@ func TestInvalidLineAfterBoundary(t *testing.T) {
 	reader := NewMultipartReader(bodyReader, "MyBoundary")
 	_, err := reader.NextPart()
 
-	if err == nil {
-		t.Error("Expected an error when parsing invalid line after boundary, got nil")
+	if !IsMalformedPartHeader(err) {
+		t.Errorf("Expected IsMalformedPartHeader error when parsing invalid line after boundary, got %v", err)
+	}
+}
+
+// TestMalformedPartHeaderRecovery tests that a part with a single bad header
+// line (no colon) followed by valid headers is recovered: the part is returned
+// with the recovered headers and a MalformedPartHeaderError, and subsequent
+// parts are parsed normally.
+func TestMalformedPartHeaderRecovery(t *testing.T) {
+	// Mirrors a real-world multipart/alternative where the second part starts
+	// with a line that has no colon before the real headers.
+	body := "--=_ab_5f6e7d\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"Content-Transfer-Encoding: 7bit\r\n" +
+		"\r\n" +
+		"Hi -- thanks for the call earlier.\r\n" +
+		"--=_ab_5f6e7d\r\n" +
+		"X-Notice this line is not a valid header field\r\n" +
+		"Content-Type: text/html; charset=utf-8\r\n" +
+		"Content-Transfer-Encoding: 7bit\r\n" +
+		"\r\n" +
+		"<html><body>phish</body></html>\r\n" +
+		"--=_ab_5f6e7d--\r\n"
+
+	r := NewMultipartReader(strings.NewReader(body), "=_ab_5f6e7d")
+
+	// Part 1: clean text/plain.
+	p, err := r.NextPart()
+	if err != nil {
+		t.Fatalf("part 1 NextPart: %v", err)
+	}
+	b, _ := ioutil.ReadAll(p)
+	if got, want := string(b), "Hi -- thanks for the call earlier."; got != want {
+		t.Errorf("part 1 body: got %q, want %q", got, want)
+	}
+
+	// Part 2: bad header line, followed by valid headers.
+	p, err = r.NextPart()
+	if !IsMalformedPartHeader(err) {
+		t.Fatalf("part 2 NextPart: expected IsMalformedPartHeader, got %v", err)
+	}
+	if p == nil {
+		t.Fatal("part 2 NextPart: expected non-nil part with recovered headers")
+	}
+	if got, want := p.Header.Get("Content-Type"), "text/html; charset=utf-8"; got != want {
+		t.Errorf("part 2 Content-Type: got %q, want %q", got, want)
+	}
+	b, _ = ioutil.ReadAll(p)
+	if got, want := string(b), "<html><body>phish</body></html>"; got != want {
+		t.Errorf("part 2 body: got %q, want %q", got, want)
+	}
+
+	// No more parts.
+	_, err = r.NextPart()
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF after final boundary, got %v", err)
+	}
+}
+
+// TestMalformedPartHeaderSkip tests that when recovery is not possible (two
+// consecutive bad header lines), the bad part is discarded and subsequent
+// valid parts are still returned.
+func TestMalformedPartHeaderSkip(t *testing.T) {
+	body := "--sep\r\n" +
+		"first bad line\r\n" +
+		"second bad line\r\n" +
+		"\r\n" +
+		"skipped body\r\n" +
+		"--sep\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"good body\r\n" +
+		"--sep--\r\n"
+
+	r := NewMultipartReader(strings.NewReader(body), "sep")
+
+	// Part 1: unrecoverable – two bad lines – returns nil part + error.
+	p, err := r.NextPart()
+	if !IsMalformedPartHeader(err) {
+		t.Fatalf("part 1 NextPart: expected IsMalformedPartHeader, got %v", err)
+	}
+	if p != nil {
+		t.Fatal("part 1 NextPart: expected nil part when recovery fails")
+	}
+
+	// Part 2: valid part is reachable after the skip.
+	p, err = r.NextPart()
+	if err != nil {
+		t.Fatalf("part 2 NextPart: %v", err)
+	}
+	if got, want := p.Header.Get("Content-Type"), "text/plain"; got != want {
+		t.Errorf("part 2 Content-Type: got %q, want %q", got, want)
+	}
+	b, _ := ioutil.ReadAll(p)
+	if got, want := string(b), "good body"; got != want {
+		t.Errorf("part 2 body: got %q, want %q", got, want)
+	}
+
+	_, err = r.NextPart()
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

My Summary:

When there is an empty line in the header section, which is a malformed line, Apple Mail still renders the HTML perfectly. We need to parse equally permissively to effectively detect phishes. When there are malformed lines in the headers, skip them and see if you can still form a valid header with subsequent lines. Return the recovered parts along with the error so the caller can decide how to proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)