### PR TITLE
textproto: fix boundary prefix collision causing empty part bodies

### DIFF
--- a/textproto/multipart.go
+++ b/textproto/multipart.go
@@ -218,8 +218,22 @@ func matchAfterPrefix(buf, prefix []byte, readErr error) int {
 		return 0
 	}
 	c := buf[len(prefix)]
-	if c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '-' {
+	if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
 		return +1
+	}
+	if c == '-' {
+		// '--boundary--' is the closing delimiter; '--boundary-suffix' is a longer,
+		// different boundary. Peek one more byte to tell them apart.
+		if len(buf) == len(prefix)+1 {
+			if readErr != nil {
+				return +1 // single '-' at EOF: treat as closing delimiter
+			}
+			return 0 // need one more byte to decide
+		}
+		if buf[len(prefix)+1] == '-' {
+			return +1 // '--boundary--': genuine closing delimiter
+		}
+		return -1 // '--boundary-X': longer boundary, not a match for this one
 	}
 	return -1
 }

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -921,3 +921,64 @@ func TestInvalidLineAfterBoundary(t *testing.T) {
 		t.Error("Expected an error when parsing invalid line after boundary, got nil")
 	}
 }
+
+// TestNestedMultipartHyphenBoundaries exercises the real-world case where inner
+// boundaries are the outer boundary plus a hyphen-digit suffix (e.g. foo-5, foo-1).
+// It reads all three levels and asserts each part has non-empty content.
+func TestNestedMultipartHyphenBoundaries(t *testing.T) {
+	const input = "--foo\r\n" +
+		"Content-Type: multipart/alternative; boundary=\"foo-5\"\r\n" +
+		"\r\n" +
+		"--foo-5\r\n" +
+		"Content-Type: multipart/related; boundary=\"foo-1\"\r\n" +
+		"\r\n" +
+		"--foo-1\r\n" +
+		"Content-Type: text/html\r\n" +
+		"\r\n" +
+		"<html>hello</html>\r\n" +
+		"--foo-1--\r\n" +
+		"--foo-5--\r\n" +
+		"--foo--\r\n"
+
+	// Level 1: outer boundary "foo" — expect one part.
+	outerPart, err := NewMultipartReader(strings.NewReader(input), "foo").NextPart()
+	if err != nil {
+		t.Fatalf("outer NextPart: %v", err)
+	}
+	outerBody, err := io.ReadAll(outerPart)
+	if err != nil {
+		t.Fatalf("reading outer part body: %v", err)
+	}
+	if len(outerBody) == 0 {
+		t.Fatal("outer part body is empty")
+	}
+
+	// Level 2: middle boundary "foo-5" — expect one part.
+	middlePart, err := NewMultipartReader(bytes.NewReader(outerBody), "foo-5").NextPart()
+	if err != nil {
+		t.Fatalf("middle NextPart: %v", err)
+	}
+	middleBody, err := io.ReadAll(middlePart)
+	if err != nil {
+		t.Fatalf("reading middle part body: %v", err)
+	}
+	if len(middleBody) == 0 {
+		t.Fatal("middle part body is empty")
+	}
+
+	// Level 3: inner boundary "foo-1" — expect one part with the HTML body.
+	innerPart, err := NewMultipartReader(bytes.NewReader(middleBody), "foo-1").NextPart()
+	if err != nil {
+		t.Fatalf("inner NextPart: %v", err)
+	}
+	if got := innerPart.Header.Get("Content-Type"); got != "text/html" {
+		t.Errorf("inner part Content-Type = %q, want %q", got, "text/html")
+	}
+	innerBody, err := io.ReadAll(innerPart)
+	if err != nil {
+		t.Fatalf("reading inner part body: %v", err)
+	}
+	if got, want := string(innerBody), "<html>hello</html>"; got != want {
+		t.Errorf("inner part body = %q, want %q", got, want)
+	}
+}

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -965,18 +965,22 @@ func TestMatchAfterPrefix(t *testing.T) {
 func TestNestedMultipartHyphenBoundaries(t *testing.T) {
 	crlf := func(s string) string { return strings.Replace(s, "\n", "\r\n", -1) }
 
-	input := crlf("--foo\n" +
-		"Content-Type: multipart/alternative; boundary=\"foo-5\"\n" +
-		"\n" +
-		"--foo-5\n" +
-		"Content-Type: multipart/related; boundary=\"foo-1\"\n" +
-		"\n" +
-		"--foo-1\n" +
+	nestedFoo1 := "--foo-1\n" +
 		"Content-Type: text/html\n" +
 		"\n" +
 		"<html>hello</html>\n" +
-		"--foo-1--\n" +
-		"--foo-5--\n" +
+		"--foo-1--"
+
+	nestedFoo5 := "--foo-5\n" +
+		"Content-Type: multipart/related; boundary=\"foo-1\"\n" +
+		"\n" +
+		nestedFoo1 + "\n" +
+		"--foo-5--"
+
+	input := crlf("--foo\n" +
+		"Content-Type: multipart/alternative; boundary=\"foo-5\"\n" +
+		"\n" +
+		nestedFoo5 + "\n" +
 		"--foo--\n")
 
 	levels := []struct {
@@ -987,24 +991,12 @@ func TestNestedMultipartHyphenBoundaries(t *testing.T) {
 		{
 			boundary:        "foo",
 			wantContentType: `multipart/alternative; boundary="foo-5"`,
-			wantBody: crlf("--foo-5\n" +
-				"Content-Type: multipart/related; boundary=\"foo-1\"\n" +
-				"\n" +
-				"--foo-1\n" +
-				"Content-Type: text/html\n" +
-				"\n" +
-				"<html>hello</html>\n" +
-				"--foo-1--\n" +
-				"--foo-5--"),
+			wantBody:        crlf(nestedFoo5),
 		},
 		{
 			boundary:        "foo-5",
 			wantContentType: `multipart/related; boundary="foo-1"`,
-			wantBody: crlf("--foo-1\n" +
-				"Content-Type: text/html\n" +
-				"\n" +
-				"<html>hello</html>\n" +
-				"--foo-1--"),
+			wantBody:        crlf(nestedFoo1),
 		},
 		{
 			boundary:        "foo-1",

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -922,83 +922,112 @@ func TestInvalidLineAfterBoundary(t *testing.T) {
 	}
 }
 
+// TestMatchAfterPrefix exercises all return paths of matchAfterPrefix, including
+// the new single-hyphen lookahead added to distinguish --boundary-- from --boundary-X.
+func TestMatchAfterPrefix(t *testing.T) {
+	eof := io.ErrUnexpectedEOF
+	prefix := []byte("\r\n--foo")
+
+	tests := []struct {
+		name     string
+		buf      []byte
+		readErr  error
+		want     int
+	}{
+		{"buf equals prefix, no err", prefix, nil, 0},
+		{"buf equals prefix, at EOF", prefix, eof, +1},
+		{"space after prefix", append(prefix, ' '), nil, +1},
+		{"tab after prefix", append(prefix, '\t'), nil, +1},
+		{"CR after prefix", append(prefix, '\r'), nil, +1},
+		{"LF after prefix", append(prefix, '\n'), nil, +1},
+		{"other char after prefix", append(prefix, 'x'), nil, -1},
+		{"closing delimiter --", append(prefix, '-', '-'), nil, +1},
+		{"hyphen-digit suffix, not a match", append(prefix, '-', '1'), nil, -1},
+		{"hyphen-letter suffix, not a match", append(prefix, '-', 'a'), nil, -1},
+		{"single hyphen, no err: need more data", append(prefix, '-'), nil, 0},
+		{"single hyphen at EOF: closing delimiter", append(prefix, '-'), eof, +1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchAfterPrefix(tc.buf, prefix, tc.readErr)
+			if got != tc.want {
+				t.Errorf("matchAfterPrefix(%q, %q, %v) = %d, want %d",
+					tc.buf, prefix, tc.readErr, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestNestedMultipartHyphenBoundaries exercises the real-world case where inner
 // boundaries are the outer boundary plus a hyphen-digit suffix (e.g. foo-5, foo-1).
 // It reads all three levels and asserts the exact header and body at each level.
 func TestNestedMultipartHyphenBoundaries(t *testing.T) {
-	const input = "--foo\r\n" +
-		"Content-Type: multipart/alternative; boundary=\"foo-5\"\r\n" +
-		"\r\n" +
-		"--foo-5\r\n" +
-		"Content-Type: multipart/related; boundary=\"foo-1\"\r\n" +
-		"\r\n" +
-		"--foo-1\r\n" +
-		"Content-Type: text/html\r\n" +
-		"\r\n" +
-		"<html>hello</html>\r\n" +
-		"--foo-1--\r\n" +
-		"--foo-5--\r\n" +
-		"--foo--\r\n"
+	crlf := func(s string) string { return strings.Replace(s, "\n", "\r\n", -1) }
 
-	// Level 1: outer boundary "foo".
-	outerPart, err := NewMultipartReader(strings.NewReader(input), "foo").NextPart()
-	if err != nil {
-		t.Fatalf("outer NextPart: %v", err)
-	}
-	if got, want := outerPart.Header.Get("Content-Type"), `multipart/alternative; boundary="foo-5"`; got != want {
-		t.Errorf("outer Content-Type = %q, want %q", got, want)
-	}
-	outerBody, err := io.ReadAll(outerPart)
-	if err != nil {
-		t.Fatalf("reading outer part body: %v", err)
-	}
-	wantOuterBody := "--foo-5\r\n" +
-		"Content-Type: multipart/related; boundary=\"foo-1\"\r\n" +
-		"\r\n" +
-		"--foo-1\r\n" +
-		"Content-Type: text/html\r\n" +
-		"\r\n" +
-		"<html>hello</html>\r\n" +
-		"--foo-1--\r\n" +
-		"--foo-5--"
-	if got := string(outerBody); got != wantOuterBody {
-		t.Errorf("outer body = %q, want %q", got, wantOuterBody)
-	}
+	input := crlf("--foo\n" +
+		"Content-Type: multipart/alternative; boundary=\"foo-5\"\n" +
+		"\n" +
+		"--foo-5\n" +
+		"Content-Type: multipart/related; boundary=\"foo-1\"\n" +
+		"\n" +
+		"--foo-1\n" +
+		"Content-Type: text/html\n" +
+		"\n" +
+		"<html>hello</html>\n" +
+		"--foo-1--\n" +
+		"--foo-5--\n" +
+		"--foo--\n")
 
-	// Level 2: middle boundary "foo-5".
-	middlePart, err := NewMultipartReader(bytes.NewReader(outerBody), "foo-5").NextPart()
-	if err != nil {
-		t.Fatalf("middle NextPart: %v", err)
-	}
-	if got, want := middlePart.Header.Get("Content-Type"), `multipart/related; boundary="foo-1"`; got != want {
-		t.Errorf("middle Content-Type = %q, want %q", got, want)
-	}
-	middleBody, err := io.ReadAll(middlePart)
-	if err != nil {
-		t.Fatalf("reading middle part body: %v", err)
-	}
-	wantMiddleBody := "--foo-1\r\n" +
-		"Content-Type: text/html\r\n" +
-		"\r\n" +
-		"<html>hello</html>\r\n" +
-		"--foo-1--"
-	if got := string(middleBody); got != wantMiddleBody {
-		t.Errorf("middle body = %q, want %q", got, wantMiddleBody)
+	levels := []struct {
+		boundary        string
+		wantContentType string
+		wantBody        string
+	}{
+		{
+			boundary:        "foo",
+			wantContentType: `multipart/alternative; boundary="foo-5"`,
+			wantBody: crlf("--foo-5\n" +
+				"Content-Type: multipart/related; boundary=\"foo-1\"\n" +
+				"\n" +
+				"--foo-1\n" +
+				"Content-Type: text/html\n" +
+				"\n" +
+				"<html>hello</html>\n" +
+				"--foo-1--\n" +
+				"--foo-5--"),
+		},
+		{
+			boundary:        "foo-5",
+			wantContentType: `multipart/related; boundary="foo-1"`,
+			wantBody: crlf("--foo-1\n" +
+				"Content-Type: text/html\n" +
+				"\n" +
+				"<html>hello</html>\n" +
+				"--foo-1--"),
+		},
+		{
+			boundary:        "foo-1",
+			wantContentType: "text/html",
+			wantBody:        "<html>hello</html>",
+		},
 	}
 
-	// Level 3: inner boundary "foo-1".
-	innerPart, err := NewMultipartReader(bytes.NewReader(middleBody), "foo-1").NextPart()
-	if err != nil {
-		t.Fatalf("inner NextPart: %v", err)
-	}
-	if got, want := innerPart.Header.Get("Content-Type"), "text/html"; got != want {
-		t.Errorf("inner Content-Type = %q, want %q", got, want)
-	}
-	innerBody, err := io.ReadAll(innerPart)
-	if err != nil {
-		t.Fatalf("reading inner part body: %v", err)
-	}
-	if got, want := string(innerBody), "<html>hello</html>"; got != want {
-		t.Errorf("inner body = %q, want %q", got, want)
+	body := []byte(input)
+	for _, level := range levels {
+		part, err := NewMultipartReader(bytes.NewReader(body), level.boundary).NextPart()
+		if err != nil {
+			t.Fatalf("NextPart for boundary %q: %v", level.boundary, err)
+		}
+		if got := part.Header.Get("Content-Type"); got != level.wantContentType {
+			t.Errorf("boundary %q: Content-Type = %q, want %q", level.boundary, got, level.wantContentType)
+		}
+		body, err = io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("reading body for boundary %q: %v", level.boundary, err)
+		}
+		if got := string(body); got != level.wantBody {
+			t.Errorf("boundary %q: body = %q, want %q", level.boundary, got, level.wantBody)
+		}
 	}
 }

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -679,6 +679,39 @@ html things
 			},
 		},
 	},
+	// Hyphen-digit suffixed inner boundaries (mirrors real-world case where outer=foo,
+	// inner=foo-5, inner-inner=foo-1). Neither --foo-5 nor --foo-1 should be matched
+	// as --foo's closing delimiter.
+	{
+		name: "inner boundaries with multiple hyphen-digit suffixes",
+		sep:  "foo",
+		in: strings.Replace(`--foo
+Content-Type: multipart/alternative; boundary="foo-5"
+
+--foo-5
+Content-Type: multipart/related; boundary="foo-1"
+
+--foo-1
+Content-Type: text/html
+
+<html>hello</html>
+--foo-1--
+--foo-5--
+--foo--`, "\n", "\r\n", -1),
+		want: []headerBody{
+			{textproto.MIMEHeader{"Content-Type": {`multipart/alternative; boundary="foo-5"`}},
+				strings.Replace(`--foo-5
+Content-Type: multipart/related; boundary="foo-1"
+
+--foo-1
+Content-Type: text/html
+
+<html>hello</html>
+--foo-1--
+--foo-5--`, "\n", "\r\n", -1),
+			},
+		},
+	},
 	// Issue 12662: Check that we don't consume the leading \r if the peekBuffer
 	// ends in '\r\n--separator-'
 	{

--- a/textproto/multipart_test.go
+++ b/textproto/multipart_test.go
@@ -924,7 +924,7 @@ func TestInvalidLineAfterBoundary(t *testing.T) {
 
 // TestNestedMultipartHyphenBoundaries exercises the real-world case where inner
 // boundaries are the outer boundary plus a hyphen-digit suffix (e.g. foo-5, foo-1).
-// It reads all three levels and asserts each part has non-empty content.
+// It reads all three levels and asserts the exact header and body at each level.
 func TestNestedMultipartHyphenBoundaries(t *testing.T) {
 	const input = "--foo\r\n" +
 		"Content-Type: multipart/alternative; boundary=\"foo-5\"\r\n" +
@@ -940,45 +940,65 @@ func TestNestedMultipartHyphenBoundaries(t *testing.T) {
 		"--foo-5--\r\n" +
 		"--foo--\r\n"
 
-	// Level 1: outer boundary "foo" — expect one part.
+	// Level 1: outer boundary "foo".
 	outerPart, err := NewMultipartReader(strings.NewReader(input), "foo").NextPart()
 	if err != nil {
 		t.Fatalf("outer NextPart: %v", err)
+	}
+	if got, want := outerPart.Header.Get("Content-Type"), `multipart/alternative; boundary="foo-5"`; got != want {
+		t.Errorf("outer Content-Type = %q, want %q", got, want)
 	}
 	outerBody, err := io.ReadAll(outerPart)
 	if err != nil {
 		t.Fatalf("reading outer part body: %v", err)
 	}
-	if len(outerBody) == 0 {
-		t.Fatal("outer part body is empty")
+	wantOuterBody := "--foo-5\r\n" +
+		"Content-Type: multipart/related; boundary=\"foo-1\"\r\n" +
+		"\r\n" +
+		"--foo-1\r\n" +
+		"Content-Type: text/html\r\n" +
+		"\r\n" +
+		"<html>hello</html>\r\n" +
+		"--foo-1--\r\n" +
+		"--foo-5--"
+	if got := string(outerBody); got != wantOuterBody {
+		t.Errorf("outer body = %q, want %q", got, wantOuterBody)
 	}
 
-	// Level 2: middle boundary "foo-5" — expect one part.
+	// Level 2: middle boundary "foo-5".
 	middlePart, err := NewMultipartReader(bytes.NewReader(outerBody), "foo-5").NextPart()
 	if err != nil {
 		t.Fatalf("middle NextPart: %v", err)
+	}
+	if got, want := middlePart.Header.Get("Content-Type"), `multipart/related; boundary="foo-1"`; got != want {
+		t.Errorf("middle Content-Type = %q, want %q", got, want)
 	}
 	middleBody, err := io.ReadAll(middlePart)
 	if err != nil {
 		t.Fatalf("reading middle part body: %v", err)
 	}
-	if len(middleBody) == 0 {
-		t.Fatal("middle part body is empty")
+	wantMiddleBody := "--foo-1\r\n" +
+		"Content-Type: text/html\r\n" +
+		"\r\n" +
+		"<html>hello</html>\r\n" +
+		"--foo-1--"
+	if got := string(middleBody); got != wantMiddleBody {
+		t.Errorf("middle body = %q, want %q", got, wantMiddleBody)
 	}
 
-	// Level 3: inner boundary "foo-1" — expect one part with the HTML body.
+	// Level 3: inner boundary "foo-1".
 	innerPart, err := NewMultipartReader(bytes.NewReader(middleBody), "foo-1").NextPart()
 	if err != nil {
 		t.Fatalf("inner NextPart: %v", err)
 	}
-	if got := innerPart.Header.Get("Content-Type"); got != "text/html" {
-		t.Errorf("inner part Content-Type = %q, want %q", got, "text/html")
+	if got, want := innerPart.Header.Get("Content-Type"), "text/html"; got != want {
+		t.Errorf("inner Content-Type = %q, want %q", got, want)
 	}
 	innerBody, err := io.ReadAll(innerPart)
 	if err != nil {
 		t.Fatalf("reading inner part body: %v", err)
 	}
 	if got, want := string(innerBody), "<html>hello</html>"; got != want {
-		t.Errorf("inner part body = %q, want %q", got, want)
+		t.Errorf("inner body = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

We need the multipart parser to distinguish between closing boundaries (`--`) and suffixed nested boundaries (`-nestedSuffix`). Nested multipart boundaries have been seen in real EMLs, and Apple Mail renders the body perfectly.

Claude Summary:
`matchAfterPrefix` previously returned `+1` (boundary match) whenever the character immediately after the boundary prefix was `-`. The intent was to handle `--boundary--` (the closing delimiter), but this also matched `--boundary-suffix` — a longer, different inner boundary.

In practice: if the outer boundary is `S0p-lc86...J` and an inner boundary is `S0p-lc86...J-5`, the outer part body reader encounters `--S0p-lc86...J-5\n`, matches the outer boundary prefix, sees `-` as the next character, and returns `+1`. `scanUntilBoundary` then reports an empty part body at byte 0, so `mdm.Body` is nil even though the EML contains HTML content.

## Fix

When `matchAfterPrefix` sees `c == '-'`, peek one more byte to distinguish the two cases:

- Next byte is also `-` →  genuine closing delimiter
- Next byte is anything else → longer boundary, not a match